### PR TITLE
add support for passing options to cluster

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -17,7 +17,9 @@ module.exports = RedisSharelatex =
 			client.healthCheck = RedisSharelatex.singleInstanceHealthCheckBuilder(client)
 		else if opts.cluster?
 			Redis = require("ioredis")
-			client = new Redis.Cluster(opts.cluster)
+			standardOpts = _.clone(opts)
+			delete standardOpts.cluster
+			client = new Redis.Cluster(opts.cluster, standardOpts)
 			client.healthCheck = RedisSharelatex.clusterHealthCheckBuilder(client)
 			RedisSharelatex._monkeyPatchIoredisExec(client)
 		else

--- a/index.coffee
+++ b/index.coffee
@@ -19,6 +19,7 @@ module.exports = RedisSharelatex =
 			Redis = require("ioredis")
 			standardOpts = _.clone(opts)
 			delete standardOpts.cluster
+			delete standardOpts.key_schema
 			client = new Redis.Cluster(opts.cluster, standardOpts)
 			client.healthCheck = RedisSharelatex.clusterHealthCheckBuilder(client)
 			RedisSharelatex._monkeyPatchIoredisExec(client)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redis-sharelatex",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Redis wrapper for node which will either use cluster, sentinal, or single instance redis",
   "main": "index.js",
   "author": "ShareLaTeX",

--- a/test.coffee
+++ b/test.coffee
@@ -23,7 +23,7 @@ describe "index", ->
 			"redis":@normalRedis
 			"ioredis": @ioredis =
 				Cluster: class Cluster
-					constructor: (@config) ->
+					constructor: (@config, @options) ->
 		@auth_pass = "1234 pass"
 		@endpoints = [
 				{host: '127.0.0.1', port: 26379},
@@ -69,11 +69,22 @@ describe "index", ->
 	describe "cluster", ->
 		beforeEach ->
 			@cluster = [{"mock": "cluster"}, { "mock": "cluster2"}]
+			@extraOptions = {keepAlive:100}
+			@settings =
+				cluster: @cluster
+				redisOptions: @extraOptions
 
-		it "should pass the options correctly though", ->
+		it "should pass the options correctly though with no options", ->
 			client = @redis.createClient cluster: @cluster
 			assert(client instanceof @ioredis.Cluster)
 			client.config.should.deep.equal @cluster
+
+		it "should pass the options correctly though with additional options", ->
+			client = @redis.createClient @settings
+			assert(client instanceof @ioredis.Cluster)
+			client.config.should.deep.equal @cluster
+			# need to use expect here because of _.clone in sandbox
+			expect(client.options).to.deep.equal {redisOptions: @extraOptions, retry_max_delay: 5000}
 
 	describe "monkey patch ioredis exec", ->
 		beforeEach ->

--- a/test.coffee
+++ b/test.coffee
@@ -73,11 +73,18 @@ describe "index", ->
 			@settings =
 				cluster: @cluster
 				redisOptions: @extraOptions
+				key_schema: {foo: (x) -> "#{x}"}
 
 		it "should pass the options correctly though with no options", ->
 			client = @redis.createClient cluster: @cluster
 			assert(client instanceof @ioredis.Cluster)
 			client.config.should.deep.equal @cluster
+
+		it "should not pass the key_schema through to the driver", ->
+			client = @redis.createClient cluster: @cluster, key_schema: "foobar"
+			assert(client instanceof @ioredis.Cluster)
+			client.config.should.deep.equal @cluster
+			expect(client.options).to.deep.equal {retry_max_delay: 5000}
 
 		it "should pass the options correctly though with additional options", ->
 			client = @redis.createClient @settings


### PR DESCRIPTION
allow options for cluster in the same way as the other redis client types