### PR TITLE
allow patch updates to ioredis 4.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redis-sharelatex",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Redis wrapper for node which will either use cluster, sentinal, or single instance redis",
   "main": "index.js",
   "author": "ShareLaTeX",
@@ -8,7 +8,7 @@
   "dependencies": {
     "async": "^2.5.0",
     "coffee-script": "1.8.0",
-    "ioredis": "4.6.0",
+    "ioredis": "~4.6.0",
     "redis": "0.12.1",
     "redis-sentinel": "0.1.1",
     "underscore": "1.7.0"


### PR DESCRIPTION
this will allow us to upgrade to 4.6.3 which may fix some errors with pubsub in redis cluster
https://github.com/luin/ioredis/issues/768
https://github.com/luin/ioredis/issues/791
https://github.com/luin/ioredis/issues/774

from 
https://github.com/luin/ioredis/releases/tag/v4.6.3
https://github.com/luin/ioredis/releases/tag/v4.6.2
https://github.com/luin/ioredis/releases/tag/v4.6.1