### PR TITLE
make ioredis default

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -6,9 +6,6 @@ module.exports = RedisSharelatex =
 		if !opts.retry_max_delay?
 			opts.retry_max_delay = 5000 # ms
 		
-		if opts.password?
-			opts.auth_pass = opts.password
-			delete opts.password
 		if opts.endpoints?
 			standardOpts = _.clone(opts)
 			delete standardOpts.endpoints
@@ -25,9 +22,9 @@ module.exports = RedisSharelatex =
 			RedisSharelatex._monkeyPatchIoredisExec(client)
 		else
 			standardOpts = _.clone(opts)
-			delete standardOpts.port
-			delete standardOpts.host
-			client = require("redis").createClient opts.port, opts.host, standardOpts
+			ioredis = require("ioredis")
+			client = new ioredis(standardOpts)
+			RedisSharelatex._monkeyPatchIoredisExec(client)
 			client.healthCheck = RedisSharelatex.singleInstanceHealthCheckBuilder(client)
 		return client
 	

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "async": "^2.5.0",
     "coffee-script": "1.8.0",
     "ioredis": "~4.6.0",
-    "redis": "0.12.1",
     "redis-sentinel": "0.1.1",
     "underscore": "1.7.0"
   },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "async": "^2.5.0",
     "coffee-script": "1.8.0",
-    "ioredis": "~4.6.0",
+    "ioredis": "~4.9.1",
     "redis-sentinel": "0.1.1",
     "underscore": "1.7.0"
   },


### PR DESCRIPTION
I've tested this on doc updater, tests pass, however some setups need modification as ioredis returns a promise which can cause mocha problems if passed all the way up the stack.

also bumps the version to 4.9.1

https://github.com/sharelatex/overleaf-google-ops/issues/270