### PR TITLE
make health check more robust

### DIFF
--- a/health.coffee
+++ b/health.coffee
@@ -1,0 +1,13 @@
+# execute this script with a redis container running to test the health check
+# starting and stopping redis with this script running is a good test
+
+redis = require "./index.coffee"
+
+rclient = redis.createClient({host:"localhost",port:"6379"})
+setInterval () ->
+    rclient.healthCheck (err) ->
+        if err?
+            console.log "HEALTH CHECK FAILED", err
+        else
+            console.log "HEALTH CHECK OK"
+, 1000

--- a/index.coffee
+++ b/index.coffee
@@ -80,7 +80,7 @@ module.exports = RedisSharelatex =
 			multi.exec (err, reply) ->
 				clearTimeout timer
 				return callback(err) if err?
-				return callback(new Error("bad response from redis health check")) if reply?[0] isnt healthCheckValue
+				return callback(new Error("bad response from redis health check")) if reply?[0] isnt healthCheckValue or reply?[1] isnt 1
 				return callback()
 
 	_monkeyPatchIoredisExec: (client) ->


### PR DESCRIPTION
following the suggestion in https://digital-science.slack.com/archives/G6256GXGS/p1568448012004500 this makes the health check more robust by reading and writing data in redis, rather than just testing a `ping` on the server.

